### PR TITLE
Use content attribute.

### DIFF
--- a/lib/HTML/Microdata.pm
+++ b/lib/HTML/Microdata.pm
@@ -131,6 +131,8 @@ sub extract_value {
 		$value = $prop->attr('value');
 	} elsif ($prop->tag eq 'time' && $prop->attr('datetime')) {
 		$value = $prop->attr('datetime');
+	} elsif (defined $prop->attr('content')) {
+		$value = $prop->attr('content');
 	} else {
 		$value = $prop->findvalue('normalize-space(.)');
 	}


### PR DESCRIPTION
Use content attribute as value of property, if it is available, instead
of the annotated text. This fixes GitHub bug #4.
