### PR TITLE
Fix RE grouping to fix <address> microdata parsing issue.

### DIFF
--- a/lib/HTML/Microdata.pm
+++ b/lib/HTML/Microdata.pm
@@ -121,9 +121,9 @@ sub extract_value {
 		$value = $opts{items}->{ $prop->id };
 	} elsif ($prop->tag eq 'meta') {
 		$value = $prop->attr('content');
-	} elsif ($prop->tag =~ m{^audio|embed|iframe|img|source|video|track$}) {
+	} elsif ($prop->tag =~ m{^(?:audio|embed|iframe|img|source|video|track)$}) {
 		$value = $self->absolute($prop->attr('src'));
-	} elsif ($prop->tag =~ m{^a|area|link$}) {
+	} elsif ($prop->tag =~ m{^(?:a|area|link)$}) {
 		$value = $self->absolute($prop->attr('href'));
 	} elsif ($prop->tag eq 'object') {
 		$value = $self->absolute($prop->attr('data'));


### PR DESCRIPTION
This fixes issue with parsing of microdata in HTML like this:

```xml
<address class="byline author vcard" itemprop="author creator" itemtype="http://schema.org/Person">
				By Benjamin Preston			</address>
```

Notice how the original regex matches the `address` tag due to missing regex grouping This in turn causes the Person microdata to be empty.
