### PR TITLE
Fix parsing of entities with `itemscope` and unanchored `itemprop`.

### DIFF
--- a/lib/HTML/Microdata.pm
+++ b/lib/HTML/Microdata.pm
@@ -62,7 +62,8 @@ sub _parse {
 
 		$items->{ $scope->id } = $item;
 
-		unless (scalar @{$scope->findnodes('./ancestor::*[@itemscope]')}) {
+		if (!scalar @{$scope->findnodes('./ancestor::*[@itemscope]')}
+			|| !$scope->attr('itemprop')) {
 			# This is top level item
 			push @{ $self->{items} }, $item;
 		}

--- a/lib/HTML/Microdata.pm
+++ b/lib/HTML/Microdata.pm
@@ -62,7 +62,7 @@ sub _parse {
 
 		$items->{ $scope->id } = $item;
 
-		unless ($scope->attr('itemprop')) {
+		unless (scalar @{$scope->findnodes('./ancestor::*[@itemscope]')}) {
 			# This is top level item
 			push @{ $self->{items} }, $item;
 		}
@@ -87,6 +87,7 @@ sub _parse {
 	for my $prop (@$props) {
 		my $value = $self->extract_value($prop, items => $items);
 		my $scope = $prop->findnodes('./ancestor::*[@itemscope]')->[-1];
+		next if ! defined $scope;
 		for my $name (split /\s+/, $prop->attr('itemprop')) {
 			$items->{ $scope->id }->{properties}->add($name => $value);
 		}


### PR DESCRIPTION
This patch makes the parser accept input where `itemscope` is on top level
item but there is also `itemprop` on the same tag that is not anchored by
higher level `itemscope`.

This situation happens on BlogSpot, e.g., <http://coderscentral.blogspot.cz/2017/06/privilege-and-idiocy.html>:

```html
<div class="post hentry uncustomized-post-template" itemprop="blogPost" itemscope="itemscope" itemtype="http://schema.org/BlogPosting">
```

Notice the `itemprop="blogPost"` that is not anchored by higher level `itemscope`.
